### PR TITLE
chore: rename config maps to use instance name

### DIFF
--- a/controllers/cortex_alertmanager_controller.go
+++ b/controllers/cortex_alertmanager_controller.go
@@ -147,6 +147,9 @@ func NewAlertManagerDeployment(
 	}
 	ref := &corev1.LocalObjectReference{Name: AlertManagerName}
 
+	configMapName := cortex.Name + CortexConfigMapNameSuffix
+	runtimeConfigMapName := cortex.Name + CortexRuntimeConfigMapNameSuffix
+
 	return &KubernetesResource{
 		obj: deploy,
 		ref: ref,
@@ -195,27 +198,17 @@ func NewAlertManagerDeployment(
 								{
 									ConfigMap: &corev1.ConfigMapProjection{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: CortexConfigMapName,
+											Name: configMapName,
 										},
 									},
 								},
 								{
 									ConfigMap: &corev1.ConfigMapProjection{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: CortexRuntimeConfigMapName,
+											Name: runtimeConfigMapName,
 										},
 									},
 								},
-							},
-						},
-					},
-				},
-				{
-					Name: CortexRuntimeConfigMapName,
-					VolumeSource: corev1.VolumeSource{
-						ConfigMap: &corev1.ConfigMapVolumeSource{
-							LocalObjectReference: corev1.LocalObjectReference{
-								Name: CortexRuntimeConfigMapName,
 							},
 						},
 					},

--- a/controllers/cortex_controller.go
+++ b/controllers/cortex_controller.go
@@ -47,8 +47,8 @@ type kubernetesResource struct {
 const FinalizerName = "cortex.opstrace.io/finalizer"
 const ServiceAccountName = "cortex"
 const CortexConfigShasumAnnotationName = "cortex-operator/cortex-config-shasum"
-const CortexConfigMapName = "cortex-config"
-const CortexRuntimeConfigMapName = "cortex-runtime-config"
+const CortexConfigMapNameSuffix = "-config"
+const CortexRuntimeConfigMapNameSuffix = "-runtime-config"
 const GossipRingServiceName = "gossip-ring"
 
 //+kubebuilder:rbac:groups=cortex.opstrace.io,resources=cortices,verbs=get;list;watch;create;update;patch;delete
@@ -121,11 +121,12 @@ func NewCortexConfigMap(
 	req ctrl.Request,
 	cortex *cortexv1alpha1.Cortex,
 ) *KubernetesResource {
+	name := cortex.Name + CortexConfigMapNameSuffix
 	// Validation errors were handled by the webhooks.
 	y, _ := cortex.AsYAML()
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      CortexConfigMapName,
+			Name:      name,
 			Namespace: req.Namespace,
 		},
 	}

--- a/controllers/cortex_controller_test.go
+++ b/controllers/cortex_controller_test.go
@@ -35,6 +35,7 @@ import (
 var _ = Describe("Cortex controller", func() {
 	const (
 		CortexName      = "test-cortex"
+		configMapName   = CortexName + CortexConfigMapNameSuffix
 		CortexNamespace = "default"
 
 		timeout  = time.Second * 10
@@ -48,6 +49,7 @@ var _ = Describe("Cortex controller", func() {
 			ctx := context.Background()
 			manifest := filepath.Join("..", "config", "samples", "cortex_v1alpha1_cortex.yaml")
 			testCortex := GetCortexTestSample(manifest)
+			testCortex.Name = CortexName
 			Expect(k8sClient.Create(ctx, testCortex)).Should(Succeed())
 		})
 
@@ -62,7 +64,7 @@ var _ = Describe("Cortex controller", func() {
 			},
 			Entry(
 				"creates a config map with cortex configuration",
-				types.NamespacedName{Name: CortexConfigMapName, Namespace: CortexNamespace},
+				types.NamespacedName{Name: configMapName, Namespace: CortexNamespace},
 				&corev1.ConfigMap{},
 				func(createdObj client.Object) {
 					_, ok := createdObj.(*corev1.ConfigMap)

--- a/controllers/cortex_ingester_controller.go
+++ b/controllers/cortex_ingester_controller.go
@@ -115,6 +115,8 @@ func NewIngesterStatefulSet(
 		CortexConfigShasumAnnotationName: cortex.Spec.ConfigSHA(),
 	}
 	ref := &corev1.LocalObjectReference{Name: name}
+	configMapName := cortex.Name + CortexConfigMapNameSuffix
+	runtimeConfigMapName := cortex.Name + CortexRuntimeConfigMapNameSuffix
 
 	return &KubernetesResource{
 		obj: sts,
@@ -187,14 +189,14 @@ func NewIngesterStatefulSet(
 								{
 									ConfigMap: &corev1.ConfigMapProjection{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: CortexConfigMapName,
+											Name: configMapName,
 										},
 									},
 								},
 								{
 									ConfigMap: &corev1.ConfigMapProjection{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: CortexRuntimeConfigMapName,
+											Name: runtimeConfigMapName,
 										},
 									},
 								},

--- a/controllers/cortex_ruler_controller.go
+++ b/controllers/cortex_ruler_controller.go
@@ -146,6 +146,8 @@ func NewRulerDeployment(
 		CortexConfigShasumAnnotationName: cortex.Spec.ConfigSHA(),
 	}
 	ref := &corev1.LocalObjectReference{Name: RulerName}
+	configMapName := cortex.Name + CortexConfigMapNameSuffix
+	runtimeConfigMapName := cortex.Name + CortexRuntimeConfigMapNameSuffix
 
 	return &KubernetesResource{
 		obj: deploy,
@@ -191,27 +193,17 @@ func NewRulerDeployment(
 								{
 									ConfigMap: &corev1.ConfigMapProjection{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: CortexConfigMapName,
+											Name: configMapName,
 										},
 									},
 								},
 								{
 									ConfigMap: &corev1.ConfigMapProjection{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: CortexRuntimeConfigMapName,
+											Name: runtimeConfigMapName,
 										},
 									},
 								},
-							},
-						},
-					},
-				},
-				{
-					Name: CortexRuntimeConfigMapName,
-					VolumeSource: corev1.VolumeSource{
-						ConfigMap: &corev1.ConfigMapVolumeSource{
-							LocalObjectReference: corev1.LocalObjectReference{
-								Name: CortexRuntimeConfigMapName,
 							},
 						},
 					},

--- a/controllers/cortex_runtime_config_controller.go
+++ b/controllers/cortex_runtime_config_controller.go
@@ -99,9 +99,10 @@ func NewCortexRuntimeConfigMap(
 	req ctrl.Request,
 	cortex *cortexv1alpha1.Cortex,
 ) (*KubernetesResource, error) {
+	name := cortex.Name + CortexRuntimeConfigMapNameSuffix
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      CortexRuntimeConfigMapName,
+			Name:      name,
 			Namespace: req.Namespace,
 		},
 	}

--- a/controllers/kubernetes_resource.go
+++ b/controllers/kubernetes_resource.go
@@ -141,6 +141,8 @@ func NewDeployment(
 		CortexConfigShasumAnnotationName: cortex.Spec.ConfigSHA(),
 	}
 	ref := &corev1.LocalObjectReference{Name: name}
+	configMapName := cortex.Name + CortexConfigMapNameSuffix
+	runtimeConfigMapName := cortex.Name + CortexRuntimeConfigMapNameSuffix
 
 	return &KubernetesResource{
 		obj: deploy,
@@ -190,27 +192,17 @@ func NewDeployment(
 								{
 									ConfigMap: &corev1.ConfigMapProjection{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: CortexConfigMapName,
+											Name: configMapName,
 										},
 									},
 								},
 								{
 									ConfigMap: &corev1.ConfigMapProjection{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: CortexRuntimeConfigMapName,
+											Name: runtimeConfigMapName,
 										},
 									},
 								},
-							},
-						},
-					},
-				},
-				{
-					Name: CortexRuntimeConfigMapName,
-					VolumeSource: corev1.VolumeSource{
-						ConfigMap: &corev1.ConfigMapVolumeSource{
-							LocalObjectReference: corev1.LocalObjectReference{
-								Name: CortexRuntimeConfigMapName,
 							},
 						},
 					},
@@ -236,6 +228,8 @@ func NewStatefulSet(
 		CortexConfigShasumAnnotationName: cortex.Spec.ConfigSHA(),
 	}
 	ref := &corev1.LocalObjectReference{Name: name}
+	configMapName := cortex.Name + CortexConfigMapNameSuffix
+	runtimeConfigMapName := cortex.Name + CortexRuntimeConfigMapNameSuffix
 
 	return &KubernetesResource{
 		obj: sts,
@@ -291,14 +285,14 @@ func NewStatefulSet(
 								{
 									ConfigMap: &corev1.ConfigMapProjection{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: CortexConfigMapName,
+											Name: configMapName,
 										},
 									},
 								},
 								{
 									ConfigMap: &corev1.ConfigMapProjection{
 										LocalObjectReference: corev1.LocalObjectReference{
-											Name: CortexRuntimeConfigMapName,
+											Name: runtimeConfigMapName,
 										},
 									},
 								},


### PR DESCRIPTION
* Avoid naming collision with an Opstrace deployment.