### PR TITLE
chore: enable response compression by default

### DIFF
--- a/api/v1alpha1/cortex_webhook.go
+++ b/api/v1alpha1/cortex_webhook.go
@@ -215,6 +215,7 @@ const DefaultCortexConfigTemplate = `
 http_prefix: ''
 api:
   alertmanager_http_prefix: /alertmanager
+  response_compression_enabled: true
 auth_enabled: true
 distributor:
   shard_by_all_labels: true


### PR DESCRIPTION
By default [enable response compression](https://cortexmetrics.io/docs/configuration/configuration-file/#supported-contents-and-default-values-of-the-config-file).